### PR TITLE
Fixed validation error with None for temporal vals

### DIFF
--- a/test_xstac.py
+++ b/test_xstac.py
@@ -455,3 +455,38 @@ def test_xarray_to_stac(ds):
         },
     }
     assert result.extra_fields["cube:variables"] == expected
+
+
+def test_validation_with_none():
+    # https://github.com/TomAugspurger/xstac/issues/9
+    template = {
+        "type": "Collection",
+        "id": "cesm2-lens",
+        "stac_version": "1.0.0",
+        "description": "desc",
+        "stac_extensions": [
+            "https://stac-extensions.github.io/datacube/v1.0.0/schema.json"
+        ],
+        "extent": {
+            "spatial": {"bbox": [[-180, -90, 180, 90]]},
+            "temporal": {
+                "interval": [["1851-01-01T00:00:00Z", "1851-01-01T00:00:00Z"]]
+            },
+        },
+        "providers": [],
+        "license": "CC0-1.0",
+        "links": [],
+    }
+    ds = xr.Dataset(
+        {
+            "data": xr.DataArray(
+                [1, 2],
+                dims=("time",),
+                coords={"time": pd.to_datetime(["2021-01-01", "2021-01-02"])},
+            )
+        }
+    )
+    ds.time.attrs["long_name"] = "time"
+    c = xarray_to_stac(ds, template, temporal_dimension="time")
+    c.normalize_hrefs("/")
+    c.validate()

--- a/test_xstac.py
+++ b/test_xstac.py
@@ -141,7 +141,7 @@ def test_xarray_to_stac(ds):
         "time": {
             "type": "temporal",
             "description": "24-hour day based on local time",
-            "values": None,
+            # "values": None,
             "extent": ["1980-07-31T00:00:00Z", "2019-07-31T00:00:00Z"],
             "step": None,
         },

--- a/xstac/_xstac.py
+++ b/xstac/_xstac.py
@@ -303,6 +303,14 @@ def xarray_to_stac(
     result["stac_collections"].append(
         "https://stac-extensions.github.io/datacube/v1.0.0/schema.json"
     )
+
+    if temporal_dimension:
+        values = result["cube:dimensions"][temporal_dimension]["values"]
+        if values is None:
+            # For some reason, including None here causes validation to fail...
+            # https://github.com/TomAugspurger/xstac/issues/9
+            del result["cube:dimensions"][temporal_dimension]["values"]
+
     collection = pystac.Collection.from_dict(result)
 
     if validate:


### PR DESCRIPTION
This works around a more fundamental problem. I haven't had a chance to debug that though.

xref https://github.com/TomAugspurger/xstac/issues/9

