### PR TITLE
Remove adlfs from required dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ requires = [
     "dask[array]",  # for chunking
     # these are just for generate
     "fsspec",
-    "adlfs",
 ]
 
 [tool.flit.scripts]


### PR DESCRIPTION
adlfs and fsspec had an incompatiblities that would break other fsspec
filesystems. This was fixed in https://github.com/intake/filesystem_spec/pull/784

We don't actually use adlfs in xstac, just when running the examples.

Closes https://github.com/TomAugspurger/xstac/issues/17