### PR TITLE
Default to CF standard axes for accessing dimension names

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
         run: python -m pip install .[dev]
 
       - name: Run tests
-        run: pytest -v
+        run: pytest tests -v
 
       - name: Lint
         run: pre-commit run --all-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ author = "Tom Augspurger"
 author-email = "taugspurger@microsoft.com"
 classifiers = [ "License :: OSI Approved :: MIT License",]
 requires = [
+    "cf_xarray",
     "xarray",
     "numpy",
     "pystac>=1.0.0b3",

--- a/test_xstac.py
+++ b/test_xstac.py
@@ -127,13 +127,7 @@ def test_xarray_to_stac(ds):
         "license": "license",
         "stac_version": "1.0.0",
     }
-    result = xarray_to_stac(
-        ds,
-        template=template,
-        temporal_dimension="time",
-        x_dimension="x",
-        y_dimension="y",
-    )
+    result = xarray_to_stac(ds, template=template)
     assert result.id == "id"
     assert isinstance(result, pystac.Collection)
     assert result.description == "description"
@@ -453,7 +447,7 @@ def test_validation_with_none():
         }
     )
     ds.time.attrs["long_name"] = "time"
-    c = xarray_to_stac(ds, template, temporal_dimension="time")
+    c = xarray_to_stac(ds, template)
     c.normalize_hrefs("/")
     c.validate()
 
@@ -468,13 +462,7 @@ def test_xarray_to_stac_item(ds):
         "properties": {"datetime": "2021-01-01T00:00:00Z"},
         "assets": {},
     }
-    result = xarray_to_stac(
-        ds,
-        template=template,
-        temporal_dimension="time",
-        x_dimension="x",
-        y_dimension="y",
-    )
+    result = xarray_to_stac(ds, template=template)
     assert result.id == "id"
     assert isinstance(result, pystac.Item)
 

--- a/test_xstac.py
+++ b/test_xstac.py
@@ -1,5 +1,6 @@
 from xstac import xarray_to_stac, fix_attrs
 from xstac._xstac import _bbox_to_geometry
+import cf_xarray
 import xarray as xr
 import numpy as np
 import pandas as pd

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,9 @@
-from xstac import xarray_to_stac, fix_attrs
-from xstac._xstac import _bbox_to_geometry
+import pytest
 import cf_xarray
-import xarray as xr
 import numpy as np
 import pandas as pd
-import pytest
-import pystac
-
-import xstac
-
+import xarray as xr
+from xstac import fix_attrs
 
 data = np.empty((40, 584, 284), dtype="float32")
 x = xr.DataArray(
@@ -118,325 +113,8 @@ def ds():
     return fix_attrs(ds)
 
 
-def test_xarray_to_stac(ds):
-    template = {
-        "id": "id",
-        "type": "Collection",
-        "links": [],
-        "description": "description",
-        "license": "license",
-        "stac_version": "1.0.0",
-    }
-    result = xarray_to_stac(ds, template=template)
-    assert result.id == "id"
-    assert isinstance(result, pystac.Collection)
-    assert result.description == "description"
-    assert result.license == "license"
-
-    dimensions = result.extra_fields["cube:dimensions"]
-    expected = {
-        "time": {
-            "type": "temporal",
-            "description": "24-hour day based on local time",
-            "extent": ["1980-07-31T00:00:00Z", "2019-07-31T00:00:00Z"],
-        },
-        "x": {
-            "type": "spatial",
-            "axis": "x",
-            "description": "x coordinate of projection",
-            "extent": [-5802250.0, -5519250.0],
-            "step": 1000.0,
-            "reference_system": {
-                "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
-                "type": "ProjectedCRS",
-                "name": "undefined",
-                "base_crs": {
-                    "name": "undefined",
-                    "datum": {
-                        "type": "GeodeticReferenceFrame",
-                        "name": "undefined",
-                        "ellipsoid": {
-                            "name": "undefined",
-                            "semi_major_axis": 6378137,
-                            "inverse_flattening": 298.257223563,
-                        },
-                    },
-                    "coordinate_system": {
-                        "subtype": "ellipsoidal",
-                        "axis": [
-                            {
-                                "name": "Longitude",
-                                "abbreviation": "lon",
-                                "direction": "east",
-                                "unit": "degree",
-                            },
-                            {
-                                "name": "Latitude",
-                                "abbreviation": "lat",
-                                "direction": "north",
-                                "unit": "degree",
-                            },
-                        ],
-                    },
-                },
-                "conversion": {
-                    "name": "unknown",
-                    "method": {
-                        "name": "Lambert Conic Conformal (2SP)",
-                        "id": {"authority": "EPSG", "code": 9802},
-                    },
-                    "parameters": [
-                        {
-                            "name": "Latitude of 1st standard parallel",
-                            "value": 25,
-                            "unit": "degree",
-                            "id": {"authority": "EPSG", "code": 8823},
-                        },
-                        {
-                            "name": "Latitude of 2nd standard parallel",
-                            "value": 60,
-                            "unit": "degree",
-                            "id": {"authority": "EPSG", "code": 8824},
-                        },
-                        {
-                            "name": "Latitude of false origin",
-                            "value": 42.5,
-                            "unit": "degree",
-                            "id": {"authority": "EPSG", "code": 8821},
-                        },
-                        {
-                            "name": "Longitude of false origin",
-                            "value": -100,
-                            "unit": "degree",
-                            "id": {"authority": "EPSG", "code": 8822},
-                        },
-                        {
-                            "name": "Easting at false origin",
-                            "value": 0,
-                            "unit": "metre",
-                            "id": {"authority": "EPSG", "code": 8826},
-                        },
-                        {
-                            "name": "Northing at false origin",
-                            "value": 0,
-                            "unit": "metre",
-                            "id": {"authority": "EPSG", "code": 8827},
-                        },
-                    ],
-                },
-                "coordinate_system": {
-                    "subtype": "Cartesian",
-                    "axis": [
-                        {
-                            "name": "Easting",
-                            "abbreviation": "E",
-                            "direction": "east",
-                            "unit": "metre",
-                        },
-                        {
-                            "name": "Northing",
-                            "abbreviation": "N",
-                            "direction": "north",
-                            "unit": "metre",
-                        },
-                    ],
-                },
-            },
-        },
-        "y": {
-            "type": "spatial",
-            "axis": "y",
-            "description": "y coordinate of projection",
-            "extent": [-622000.0, -39000.0],
-            "step": -1000.0,
-            "reference_system": {
-                "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
-                "type": "ProjectedCRS",
-                "name": "undefined",
-                "base_crs": {
-                    "name": "undefined",
-                    "datum": {
-                        "type": "GeodeticReferenceFrame",
-                        "name": "undefined",
-                        "ellipsoid": {
-                            "name": "undefined",
-                            "semi_major_axis": 6378137,
-                            "inverse_flattening": 298.257223563,
-                        },
-                    },
-                    "coordinate_system": {
-                        "subtype": "ellipsoidal",
-                        "axis": [
-                            {
-                                "name": "Longitude",
-                                "abbreviation": "lon",
-                                "direction": "east",
-                                "unit": "degree",
-                            },
-                            {
-                                "name": "Latitude",
-                                "abbreviation": "lat",
-                                "direction": "north",
-                                "unit": "degree",
-                            },
-                        ],
-                    },
-                },
-                "conversion": {
-                    "name": "unknown",
-                    "method": {
-                        "name": "Lambert Conic Conformal (2SP)",
-                        "id": {"authority": "EPSG", "code": 9802},
-                    },
-                    "parameters": [
-                        {
-                            "name": "Latitude of 1st standard parallel",
-                            "value": 25,
-                            "unit": "degree",
-                            "id": {"authority": "EPSG", "code": 8823},
-                        },
-                        {
-                            "name": "Latitude of 2nd standard parallel",
-                            "value": 60,
-                            "unit": "degree",
-                            "id": {"authority": "EPSG", "code": 8824},
-                        },
-                        {
-                            "name": "Latitude of false origin",
-                            "value": 42.5,
-                            "unit": "degree",
-                            "id": {"authority": "EPSG", "code": 8821},
-                        },
-                        {
-                            "name": "Longitude of false origin",
-                            "value": -100,
-                            "unit": "degree",
-                            "id": {"authority": "EPSG", "code": 8822},
-                        },
-                        {
-                            "name": "Easting at false origin",
-                            "value": 0,
-                            "unit": "metre",
-                            "id": {"authority": "EPSG", "code": 8826},
-                        },
-                        {
-                            "name": "Northing at false origin",
-                            "value": 0,
-                            "unit": "metre",
-                            "id": {"authority": "EPSG", "code": 8827},
-                        },
-                    ],
-                },
-                "coordinate_system": {
-                    "subtype": "Cartesian",
-                    "axis": [
-                        {
-                            "name": "Easting",
-                            "abbreviation": "E",
-                            "direction": "east",
-                            "unit": "metre",
-                        },
-                        {
-                            "name": "Northing",
-                            "abbreviation": "N",
-                            "direction": "north",
-                            "unit": "metre",
-                        },
-                    ],
-                },
-            },
-        },
-    }
-    assert dimensions == expected
-    expected = {
-        "lat": {
-            "type": "auxiliary",
-            "description": "latitude coordinate",
-            "dimensions": ["y", "x"],
-            "unit": "degrees_north",
-            "shape": [584, 284],
-            "attrs": {
-                "units": "degrees_north",
-                "long_name": "latitude coordinate",
-                "standard_name": "latitude",
-            },
-        },
-        "lon": {
-            "type": "auxiliary",
-            "description": "longitude coordinate",
-            "dimensions": ["y", "x"],
-            "unit": "degrees_east",
-            "shape": [584, 284],
-            "attrs": {
-                "units": "degrees_east",
-                "long_name": "longitude coordinate",
-                "standard_name": "longitude",
-            },
-        },
-        "prcp": {
-            "type": "data",
-            "description": "annual total precipitation",
-            "dimensions": ["time", "y", "x"],
-            "unit": "mm",
-            "shape": [40, 584, 284],
-            "attrs": {
-                "grid_mapping": "lambert_conformal_conic",
-                "cell_methods": "area: mean time: sum within days time: sum over days",
-                "units": "mm",
-                "long_name": "annual total precipitation",
-            },
-        },
-        "swe": {
-            "type": "data",
-            "dimensions": ["time", "y", "x"],
-            "shape": [40, 584, 284],
-            "attrs": {},
-        },
-        "time_bnds": {
-            "type": "data",
-            "dimensions": ["time", "nv"],
-            "shape": [40, 2],
-            "attrs": {"time": "days since 1950-01-01 00:00:00"},
-        },
-        "lambert_conformal_conic": {
-            "type": "data",
-            "dimensions": [],
-            "shape": [],
-            "attrs": {
-                "grid_mapping_name": "lambert_conformal_conic",
-                "longitude_of_central_meridian": -100.0,
-                "latitude_of_projection_origin": 42.5,
-                "false_easting": 0.0,
-                "false_northing": 0.0,
-                "standard_parallel": [25.0, 60.0],
-                "semi_major_axis": 6378137.0,
-                "inverse_flattening": 298.257223563,
-            },
-        },
-    }
-    assert result.extra_fields["cube:variables"] == expected
-
-
-def test_validation_with_none():
-    # https://github.com/TomAugspurger/xstac/issues/9
-    template = {
-        "type": "Collection",
-        "id": "cesm2-lens",
-        "stac_version": "1.0.0",
-        "description": "desc",
-        "stac_extensions": [
-            "https://stac-extensions.github.io/datacube/v2.0.0/schema.json"
-        ],
-        "extent": {
-            "spatial": {"bbox": [[-180, -90, 180, 90]]},
-            "temporal": {
-                "interval": [["1851-01-01T00:00:00Z", "1851-01-01T00:00:00Z"]]
-            },
-        },
-        "providers": [],
-        "license": "CC0-1.0",
-        "links": [],
-    }
+@pytest.fixture
+def ds_without_spatial_dims():
     ds = xr.Dataset(
         {
             "data": xr.DataArray(
@@ -447,12 +125,24 @@ def test_validation_with_none():
         }
     )
     ds.time.attrs["long_name"] = "time"
-    c = xarray_to_stac(ds, template)
-    c.normalize_hrefs("/")
-    c.validate()
+    return ds
 
 
-def test_xarray_to_stac_item(ds):
+@pytest.fixture
+def collection_template():
+    template = {
+        "id": "id",
+        "type": "Collection",
+        "links": [],
+        "description": "description",
+        "license": "license",
+        "stac_version": "1.0.0",
+    }
+    return template
+
+
+@pytest.fixture
+def item_template():
     template = {
         "id": "id",
         "type": "Feature",
@@ -462,11 +152,11 @@ def test_xarray_to_stac_item(ds):
         "properties": {"datetime": "2021-01-01T00:00:00Z"},
         "assets": {},
     }
-    result = xarray_to_stac(ds, template=template)
-    assert result.id == "id"
-    assert isinstance(result, pystac.Item)
+    return template
 
-    dimensions = result.properties["cube:dimensions"]
+
+@pytest.fixture
+def collection_expected_dims():
     expected = {
         "time": {
             "type": "temporal",
@@ -680,7 +370,11 @@ def test_xarray_to_stac_item(ds):
             },
         },
     }
-    assert dimensions == expected
+    return expected
+
+
+@pytest.fixture
+def collection_expected_vars():
     expected = {
         "lat": {
             "type": "auxiliary",
@@ -747,21 +441,293 @@ def test_xarray_to_stac_item(ds):
             },
         },
     }
-    assert result.properties["cube:variables"] == expected
-
-    assert result.properties["start_datetime"] == "1980-07-31T00:00:00Z"
-    assert result.properties["end_datetime"] == "2019-07-31T00:00:00Z"
+    return expected
 
 
-def test_bbox_to_geometry():
-    import shapely.geometry
+@pytest.fixture
+def item_expected_dims():
+    expected = {
+        "time": {
+            "type": "temporal",
+            "description": "24-hour day based on local time",
+            "extent": ["1980-07-31T00:00:00Z", "2019-07-31T00:00:00Z"],
+        },
+        "x": {
+            "type": "spatial",
+            "axis": "x",
+            "description": "x coordinate of projection",
+            "extent": [-5802250.0, -5519250.0],
+            "step": 1000.0,
+            "reference_system": {
+                "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
+                "type": "ProjectedCRS",
+                "name": "undefined",
+                "base_crs": {
+                    "name": "undefined",
+                    "datum": {
+                        "type": "GeodeticReferenceFrame",
+                        "name": "undefined",
+                        "ellipsoid": {
+                            "name": "undefined",
+                            "semi_major_axis": 6378137,
+                            "inverse_flattening": 298.257223563,
+                        },
+                    },
+                    "coordinate_system": {
+                        "subtype": "ellipsoidal",
+                        "axis": [
+                            {
+                                "name": "Longitude",
+                                "abbreviation": "lon",
+                                "direction": "east",
+                                "unit": "degree",
+                            },
+                            {
+                                "name": "Latitude",
+                                "abbreviation": "lat",
+                                "direction": "north",
+                                "unit": "degree",
+                            },
+                        ],
+                    },
+                },
+                "conversion": {
+                    "name": "unknown",
+                    "method": {
+                        "name": "Lambert Conic Conformal (2SP)",
+                        "id": {"authority": "EPSG", "code": 9802},
+                    },
+                    "parameters": [
+                        {
+                            "name": "Latitude of 1st standard parallel",
+                            "value": 25,
+                            "unit": "degree",
+                            "id": {"authority": "EPSG", "code": 8823},
+                        },
+                        {
+                            "name": "Latitude of 2nd standard parallel",
+                            "value": 60,
+                            "unit": "degree",
+                            "id": {"authority": "EPSG", "code": 8824},
+                        },
+                        {
+                            "name": "Latitude of false origin",
+                            "value": 42.5,
+                            "unit": "degree",
+                            "id": {"authority": "EPSG", "code": 8821},
+                        },
+                        {
+                            "name": "Longitude of false origin",
+                            "value": -100,
+                            "unit": "degree",
+                            "id": {"authority": "EPSG", "code": 8822},
+                        },
+                        {
+                            "name": "Easting at false origin",
+                            "value": 0,
+                            "unit": "metre",
+                            "id": {"authority": "EPSG", "code": 8826},
+                        },
+                        {
+                            "name": "Northing at false origin",
+                            "value": 0,
+                            "unit": "metre",
+                            "id": {"authority": "EPSG", "code": 8827},
+                        },
+                    ],
+                },
+                "coordinate_system": {
+                    "subtype": "Cartesian",
+                    "axis": [
+                        {
+                            "name": "Easting",
+                            "abbreviation": "E",
+                            "direction": "east",
+                            "unit": "metre",
+                        },
+                        {
+                            "name": "Northing",
+                            "abbreviation": "N",
+                            "direction": "north",
+                            "unit": "metre",
+                        },
+                    ],
+                },
+            },
+        },
+        "y": {
+            "type": "spatial",
+            "axis": "y",
+            "description": "y coordinate of projection",
+            "extent": [-622000.0, -39000.0],
+            "step": -1000.0,
+            "reference_system": {
+                "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
+                "type": "ProjectedCRS",
+                "name": "undefined",
+                "base_crs": {
+                    "name": "undefined",
+                    "datum": {
+                        "type": "GeodeticReferenceFrame",
+                        "name": "undefined",
+                        "ellipsoid": {
+                            "name": "undefined",
+                            "semi_major_axis": 6378137,
+                            "inverse_flattening": 298.257223563,
+                        },
+                    },
+                    "coordinate_system": {
+                        "subtype": "ellipsoidal",
+                        "axis": [
+                            {
+                                "name": "Longitude",
+                                "abbreviation": "lon",
+                                "direction": "east",
+                                "unit": "degree",
+                            },
+                            {
+                                "name": "Latitude",
+                                "abbreviation": "lat",
+                                "direction": "north",
+                                "unit": "degree",
+                            },
+                        ],
+                    },
+                },
+                "conversion": {
+                    "name": "unknown",
+                    "method": {
+                        "name": "Lambert Conic Conformal (2SP)",
+                        "id": {"authority": "EPSG", "code": 9802},
+                    },
+                    "parameters": [
+                        {
+                            "name": "Latitude of 1st standard parallel",
+                            "value": 25,
+                            "unit": "degree",
+                            "id": {"authority": "EPSG", "code": 8823},
+                        },
+                        {
+                            "name": "Latitude of 2nd standard parallel",
+                            "value": 60,
+                            "unit": "degree",
+                            "id": {"authority": "EPSG", "code": 8824},
+                        },
+                        {
+                            "name": "Latitude of false origin",
+                            "value": 42.5,
+                            "unit": "degree",
+                            "id": {"authority": "EPSG", "code": 8821},
+                        },
+                        {
+                            "name": "Longitude of false origin",
+                            "value": -100,
+                            "unit": "degree",
+                            "id": {"authority": "EPSG", "code": 8822},
+                        },
+                        {
+                            "name": "Easting at false origin",
+                            "value": 0,
+                            "unit": "metre",
+                            "id": {"authority": "EPSG", "code": 8826},
+                        },
+                        {
+                            "name": "Northing at false origin",
+                            "value": 0,
+                            "unit": "metre",
+                            "id": {"authority": "EPSG", "code": 8827},
+                        },
+                    ],
+                },
+                "coordinate_system": {
+                    "subtype": "Cartesian",
+                    "axis": [
+                        {
+                            "name": "Easting",
+                            "abbreviation": "E",
+                            "direction": "east",
+                            "unit": "metre",
+                        },
+                        {
+                            "name": "Northing",
+                            "abbreviation": "N",
+                            "direction": "north",
+                            "unit": "metre",
+                        },
+                    ],
+                },
+            },
+        },
+    }
+    return expected
 
-    bbox = [
-        -160.2988400944475,
-        17.960033949329812,
-        -154.7780670634169,
-        23.51232608231902,
-    ]
-    result = shapely.geometry.mapping(shapely.geometry.shape(_bbox_to_geometry(bbox)))
-    expected = shapely.geometry.mapping(shapely.geometry.box(*bbox))
-    assert result == expected
+
+@pytest.fixture
+def item_expected_vars():
+    expected = {
+        "lat": {
+            "type": "auxiliary",
+            "description": "latitude coordinate",
+            "dimensions": ["y", "x"],
+            "unit": "degrees_north",
+            "shape": [584, 284],
+            "attrs": {
+                "units": "degrees_north",
+                "long_name": "latitude coordinate",
+                "standard_name": "latitude",
+            },
+        },
+        "lon": {
+            "type": "auxiliary",
+            "description": "longitude coordinate",
+            "dimensions": ["y", "x"],
+            "unit": "degrees_east",
+            "shape": [584, 284],
+            "attrs": {
+                "units": "degrees_east",
+                "long_name": "longitude coordinate",
+                "standard_name": "longitude",
+            },
+        },
+        "prcp": {
+            "type": "data",
+            "description": "annual total precipitation",
+            "dimensions": ["time", "y", "x"],
+            "unit": "mm",
+            "shape": [40, 584, 284],
+            "attrs": {
+                "grid_mapping": "lambert_conformal_conic",
+                "cell_methods": "area: mean time: sum within days time: sum over days",
+                "units": "mm",
+                "long_name": "annual total precipitation",
+            },
+        },
+        "swe": {
+            "type": "data",
+            "dimensions": ["time", "y", "x"],
+            "shape": [40, 584, 284],
+            "attrs": {},
+        },
+        "time_bnds": {
+            "type": "data",
+            "dimensions": ["time", "nv"],
+            "shape": [40, 2],
+            "attrs": {"time": "days since 1950-01-01 00:00:00"},
+        },
+        "lambert_conformal_conic": {
+            "type": "data",
+            "dimensions": [],
+            "shape": [],
+            "attrs": {
+                "grid_mapping_name": "lambert_conformal_conic",
+                "longitude_of_central_meridian": -100.0,
+                "latitude_of_projection_origin": 42.5,
+                "false_easting": 0.0,
+                "false_northing": 0.0,
+                "standard_parallel": [25.0, 60.0],
+                "semi_major_axis": 6378137.0,
+                "inverse_flattening": 298.257223563,
+            },
+        },
+    }
+    return expected

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-import cf_xarray
 import numpy as np
 import pandas as pd
 import xarray as xr

--- a/tests/test_xstac.py
+++ b/tests/test_xstac.py
@@ -93,10 +93,3 @@ def test_bbox_to_geometry():
 def test_missing_dims_error(ds_without_spatial_dims, collection_template):
     with pytest.raises(KeyError):
         _ = xarray_to_stac(ds_without_spatial_dims, collection_template)
-
-
-def test_cf_namespace_error(collection_template):
-    delattr(xr.Dataset, "cf")
-    ds_ = xr.Dataset({"data": xr.DataArray([1, 2])})
-    with pytest.raises(AttributeError):
-        _ = xarray_to_stac(ds_, collection_template)

--- a/tests/test_xstac.py
+++ b/tests/test_xstac.py
@@ -1,0 +1,76 @@
+from xstac import xarray_to_stac
+from xstac._xstac import _bbox_to_geometry
+import cf_xarray
+import pytest
+import pystac
+
+import xstac
+
+
+def test_xarray_to_stac(
+    ds, collection_template, collection_expected_dims, collection_expected_vars
+):
+    result = xarray_to_stac(ds, template=collection_template)
+    assert result.id == "id"
+    assert isinstance(result, pystac.Collection)
+    assert result.description == "description"
+    assert result.license == "license"
+
+    dimensions = result.extra_fields["cube:dimensions"]
+    assert dimensions == collection_expected_dims
+    assert result.extra_fields["cube:variables"] == collection_expected_vars
+
+
+def test_validation_with_none(ds_without_spatial_dims):
+    # https://github.com/TomAugspurger/xstac/issues/9
+    template = {
+        "type": "Collection",
+        "id": "cesm2-lens",
+        "stac_version": "1.0.0",
+        "description": "desc",
+        "stac_extensions": [
+            "https://stac-extensions.github.io/datacube/v2.0.0/schema.json"
+        ],
+        "extent": {
+            "spatial": {"bbox": [[-180, -90, 180, 90]]},
+            "temporal": {
+                "interval": [["1851-01-01T00:00:00Z", "1851-01-01T00:00:00Z"]]
+            },
+        },
+        "providers": [],
+        "license": "CC0-1.0",
+        "links": [],
+    }
+    c = xarray_to_stac(
+        ds_without_spatial_dims, template, x_dimension=False, y_dimension=False
+    )
+    c.normalize_hrefs("/")
+    c.validate()
+
+
+def test_xarray_to_stac_item(ds, item_template, item_expected_dims, item_expected_vars):
+
+    result = xarray_to_stac(ds, template=item_template)
+    assert result.id == "id"
+    assert isinstance(result, pystac.Item)
+
+    dimensions = result.properties["cube:dimensions"]
+    assert dimensions == item_expected_dims
+    assert result.properties["cube:variables"] == item_expected_vars
+
+    assert result.properties["start_datetime"] == "1980-07-31T00:00:00Z"
+    assert result.properties["end_datetime"] == "2019-07-31T00:00:00Z"
+
+
+def test_bbox_to_geometry():
+    import shapely.geometry
+
+    bbox = [
+        -160.2988400944475,
+        17.960033949329812,
+        -154.7780670634169,
+        23.51232608231902,
+    ]
+    result = shapely.geometry.mapping(shapely.geometry.shape(_bbox_to_geometry(bbox)))
+    expected = shapely.geometry.mapping(shapely.geometry.box(*bbox))
+    assert result == expected

--- a/xstac/_generate.py
+++ b/xstac/_generate.py
@@ -8,6 +8,7 @@ import sys
 import argparse
 import json
 import fsspec
+import cf_xarray
 import xarray as xr
 
 import xstac
@@ -40,16 +41,10 @@ def parse_args(args=None):
 
     parser.add_argument("--reference-system", default=None)
     parser.add_argument(
-        "--temporal_dimension",
-        default="time",
-        help="Coordinate name for the 'time' dimension",
+        "--temporal_dimension", help="Coordinate name for the 'time' dimension"
     )
-    parser.add_argument(
-        "--x-dimension", default="x", help="Coordinate name for the 'x' dimension"
-    )
-    parser.add_argument(
-        "--y-dimension", default="y", help="Coordinate name for the 'y' dimension"
-    )
+    parser.add_argument("--x-dimension", help="Coordinate name for the 'x' dimension")
+    parser.add_argument("--y-dimension", help="Coordinate name for the 'y' dimension")
     parser.add_argument(
         "--no-validate",
         action="store_false",
@@ -62,9 +57,9 @@ def parse_args(args=None):
 def generate(
     template,
     asset_key,
-    x_dimension="x",
-    y_dimension="y",
-    temporal_dimension="time",
+    x_dimension=None,
+    y_dimension=None,
+    temporal_dimension=None,
     reference_system=None,
     validate: bool = True,
 ):

--- a/xstac/_xstac.py
+++ b/xstac/_xstac.py
@@ -4,6 +4,7 @@ xstac
 import copy
 import json
 from pystac import stac_object
+import cf_xarray
 import xarray as xr
 import numpy as np
 import pystac
@@ -19,17 +20,6 @@ CF_STANDARD_AXES = dict(temporal_dimension="T", x_dimension="X", y_dimension="Y"
 
 
 def maybe_use_cf_standard_axis(kw, kw_name, ds):
-    GENERIC_SUGGESTION = (
-        f"Alternatively, pass `{kw_name}` as a string cooresponding to the name of the "
-        f"dataset's {kw_name}."
-        # "If the dataset does not have a {kw_name}, pass `{kw_name}=False`."
-    )
-    if not hasattr(ds, "cf"):
-        raise AttributeError(
-            f"Kwarg `{kw_name}` is None and the dataset does not have a `cf` namespace. Please "
-            f"ensure that `cf_xarray` (https://cf-xarray.readthedocs.io/) is imported in the "
-            f"module where you've opened the dataset. {GENERIC_SUGGESTION}"
-        )
     if kw is None:
         try:
             kw = ds.cf[CF_STANDARD_AXES[kw_name]].name
@@ -38,7 +28,9 @@ def maybe_use_cf_standard_axis(kw, kw_name, ds):
                 f"Kwarg `{kw_name}` is None and `{CF_STANDARD_AXES[kw_name]}` is not a key of "
                 f"the dataset's `cf` namespace. Make `ds.cf['{CF_STANDARD_AXES[kw_name]}']` "
                 "accessible via `cf_xarray`'s `guess_coord_axis` method or by manually editing the "
-                f"dataset's attributes according to http://cfconventions.org. {GENERIC_SUGGESTION}"
+                "dataset's attributes according to http://cfconventions.org. Alternatively, pass "
+                f"`{kw_name}` as a string cooresponding to the name of the dataset's {kw_name}."
+                # "If the dataset does not have a {kw_name}, pass `{kw_name}=False`."
             ) from e
     return kw
 

--- a/xstac/_xstac.py
+++ b/xstac/_xstac.py
@@ -20,8 +20,9 @@ CF_STANDARD_AXES = dict(temporal_dimension="T", x_dimension="X", y_dimension="Y"
 
 def maybe_use_cf_standard_axis(kw, kw_name, ds):
     GENERIC_SUGGESTION = (
-        f"Alternatively, pass `{kw_name}` as a string cooresponding to a the name of the "
-        f"dataset's {kw_name}. If the dataset does not have a {kw_name}, pass `{kw_name}=False`."
+        f"Alternatively, pass `{kw_name}` as a string cooresponding to the name of the "
+        f"dataset's {kw_name}."
+        # "If the dataset does not have a {kw_name}, pass `{kw_name}=False`."
     )
     if not hasattr(ds, "cf"):
         raise AttributeError(

--- a/xstac/_xstac.py
+++ b/xstac/_xstac.py
@@ -18,22 +18,20 @@ logger = logging.getLogger(__name__)
 
 SCHEMA_URI = "https://stac-extensions.github.io/datacube/v2.0.0/schema.json"
 
-CF_STANDARD_DIMS = dict(
-    temporal_dimension="time", x_dimension="longitude", y_dimension="latitude"
-)
+CF_STANDARD_AXES = dict(temporal_dimension="T", x_dimension="X", y_dimension="Y")
 
 
-def maybe_use_cf_standard_name(kw, kw_name, ds):
+def maybe_use_cf_standard_axis(kw, kw_name, ds):
     if kw is None:
         try:
-            kw = ds.cf[CF_STANDARD_DIMS[kw_name]].name
+            kw = ds.cf[CF_STANDARD_AXES[kw_name]].name
         except KeyError:
             logger.warning(
-                f"Kwarg `{kw_name}` is None and `{CF_STANDARD_DIMS[kw_name]}` is not a valid key "
+                f"Kwarg `{kw_name}` is None and `{CF_STANDARD_AXES[kw_name]}` is not a valid key "
                 "of the provided dataset's `cf` namespace. Therefore, STAC object is generating "
                 f"without a `{kw_name}` in its Datacube Extension. To correct this, either pass a "
-                f"string value to `{kw_name}`, or make this attribute accessible via the cf "
-                "namespace using, e.g., `cf_xarray`'s `guess_coord_axis` method."
+                f"string value to `{kw_name}`, or make `ds.cf['{CF_STANDARD_AXES[kw_name]}']` "
+                "accessible using, e.g., `cf_xarray`'s `guess_coord_axis` method."
             )
     return kw
 
@@ -331,11 +329,11 @@ def xarray_to_stac(
     **additional_dimensions:
         A dictionary with keys ``extent``, ``values``, ``step``.
     """
-    temporal_dimension = maybe_use_cf_standard_name(
+    temporal_dimension = maybe_use_cf_standard_axis(
         temporal_dimension, "temporal_dimension", ds
     )
-    x_dimension = maybe_use_cf_standard_name(x_dimension, "x_dimension", ds)
-    y_dimension = maybe_use_cf_standard_name(y_dimension, "y_dimension", ds)
+    x_dimension = maybe_use_cf_standard_axis(x_dimension, "x_dimension", ds)
+    y_dimension = maybe_use_cf_standard_axis(y_dimension, "y_dimension", ds)
 
     datacube = build_datacube(
         ds,


### PR DESCRIPTION
A continuation of https://github.com/TomAugspurger/xstac/pull/19, which I accidentally closed.

This PR achieves the recommendation made in https://github.com/TomAugspurger/xstac/pull/19#issuecomment-967178422 (with the exception of the reference system part), in that 

```console
$ xstac examples/terraclimate/item-template.json \
    zarr-https examples/terraclimate/item.json --reference-system=4326
```
now yields the same result as 
```console
$ xstac examples/terraclimate/item-template.json \
    zarr-https examples/terraclimate/item.json \
    --x-dimension=lon --y-dimension=lat --reference-system=4326
```
because the correct values for the x and y dimensions are inferred from the CF namespace in

```python
# xstac/_xstac.py L21-36

CF_STANDARD_AXES = dict(temporal_dimension="T", x_dimension="X", y_dimension="Y")


def maybe_use_cf_standard_axis(kw, kw_name, ds):
    if kw is None:
        try:
            kw = ds.cf[CF_STANDARD_AXES[kw_name]].name
        except KeyError:
            logger.warning(
                f"Kwarg `{kw_name}` is None and `{CF_STANDARD_AXES[kw_name]}` is not a valid key "
                "of the provided dataset's `cf` namespace. Therefore, STAC object is generating "
                f"without a `{kw_name}` in its Datacube Extension. To correct this, either pass a "
                f"string value to `{kw_name}`, or make `ds.cf['{CF_STANDARD_AXES[kw_name]}']` "
                "accessible using, e.g., `cf_xarray`'s `guess_coord_axis` method."
            )
    return kw
```
which is called on each dimension kwarg in `xarray_to_stac`.

The logger warning is my attempt to make it clear to the user what's happening if the key is missing; we don't want to raise an error because there may be situations where dimensions are intentionally omitted, as noted in https://github.com/TomAugspurger/xstac/pull/19#issuecomment-966656620.

I'm using the axes names instead of the standard names, because I understand them to be more generalizable than "latitude" and "longitude". The axes-based approach does work both for the existing tests as well as the Terraclimate example. If we do want to go this route, I could build in some additional testing for explicit dimension name passing as well as the `KeyError` edge case.