### PR TITLE
extend `xstac.fix_attrs` to convert `numpy` scalars to python types

### DIFF
--- a/tests/test_xstac.py
+++ b/tests/test_xstac.py
@@ -1,14 +1,30 @@
 import pyproj
 import pytest
 import pystac
+import numpy as np
 import xarray as xr
 
-from xstac import xarray_to_stac
+from xstac import xarray_to_stac, fix_attrs
 from xstac._xstac import _bbox_to_geometry, maybe_infer_reference_system
 
 
 # def test_no_time_dimension(ds, collection_template):
 #    _ = xarray_to_stac(ds, template=collection_template, temporal_dimension=False)
+
+
+def test_fix_attrs():
+    attrs = {"array": np.array([0, 1]), "scalar": np.int8(12)}
+    fixed_attrs = {"array": [0, 1], "scalar": 12}
+
+    ds = xr.Dataset({"a": ((), [], attrs)}, coords={"x": ((), [], attrs)}, attrs=attrs)
+    actual = fix_attrs(ds)
+
+    expected = xr.Dataset(
+        {"a": ((), [], fixed_attrs)},
+        coords={"x": ((), [], fixed_attrs)},
+        attrs=fixed_attrs,
+    )
+    xr.testing.assert_identical(actual, expected)
 
 
 @pytest.mark.parametrize("explicit_dims", [False, True])

--- a/tests/test_xstac.py
+++ b/tests/test_xstac.py
@@ -16,12 +16,12 @@ def test_fix_attrs():
     attrs = {"array": np.array([0, 1]), "scalar": np.int8(12)}
     fixed_attrs = {"array": [0, 1], "scalar": 12}
 
-    ds = xr.Dataset({"a": ((), [], attrs)}, coords={"x": ((), [], attrs)}, attrs=attrs)
+    ds = xr.Dataset({"a": ((), 0, attrs)}, coords={"x": ((), 0, attrs)}, attrs=attrs)
     actual = fix_attrs(ds)
 
     expected = xr.Dataset(
-        {"a": ((), [], fixed_attrs)},
-        coords={"x": ((), [], fixed_attrs)},
+        {"a": ((), 0, fixed_attrs)},
+        coords={"x": ((), 0, fixed_attrs)},
         attrs=fixed_attrs,
     )
     xr.testing.assert_identical(actual, expected)

--- a/xstac/_xstac.py
+++ b/xstac/_xstac.py
@@ -62,7 +62,7 @@ def fix_attrs(ds):
     def fix_dict(attrs):
         return {
             attr_name: (
-                list(attr_value)
+                attr_value.tolist()
                 if isinstance(attr_value, np.ndarray)
                 else attr_value
             )

--- a/xstac/_xstac.py
+++ b/xstac/_xstac.py
@@ -59,15 +59,14 @@ def _bbox_to_geometry(bbox):
 
 
 def fix_attrs(ds):
+    def fix_value(value):
+        if isinstance(value, (np.ndarray, np.number)):
+            return value.tolist()
+
+        return value
+
     def fix_dict(attrs):
-        return {
-            attr_name: (
-                attr_value.tolist()
-                if isinstance(attr_value, (np.ndarray, np.number))
-                else attr_value
-            )
-            for attr_name, attr_value in attrs.items()
-        }
+        return {name: fix_value(value) for name, value in attrs.items()}
 
     ds = type(ds)(ds)
 

--- a/xstac/_xstac.py
+++ b/xstac/_xstac.py
@@ -63,7 +63,7 @@ def fix_attrs(ds):
         return {
             attr_name: (
                 attr_value.tolist()
-                if isinstance(attr_value, np.ndarray)
+                if isinstance(attr_value, (np.ndarray, np.number))
                 else attr_value
             )
             for attr_name, attr_value in attrs.items()

--- a/xstac/_xstac.py
+++ b/xstac/_xstac.py
@@ -68,7 +68,7 @@ def fix_attrs(ds):
     def fix_dict(attrs):
         return {name: fix_value(value) for name, value in attrs.items()}
 
-    ds = type(ds)(ds)
+    ds = ds.copy()
 
     for k, v in ds.variables.items():
         v.attrs = fix_dict(v.attrs)

--- a/xstac/_xstac.py
+++ b/xstac/_xstac.py
@@ -59,12 +59,22 @@ def _bbox_to_geometry(bbox):
 
 
 def fix_attrs(ds):
+    def fix_dict(attrs):
+        return {
+            attr_name: (
+                list(attr_value)
+                if isinstance(attr_value, np.ndarray)
+                else attr_value
+            )
+            for attr_name, attr_value in attrs.items()
+        }
+
     ds = type(ds)(ds)
 
-    for k, v in ds.items():
-        for attr_name, attr_value in v.attrs.items():
-            if isinstance(attr_value, np.ndarray):
-                ds[k].attrs[attr_name] = list(attr_value)
+    for k, v in ds.variables.items():
+        v.attrs = fix_dict(v.attrs)
+    ds.attrs = fix_dict(ds.attrs)
+
     return ds
 
 


### PR DESCRIPTION
Just like `numpy` arrays, `numpy` scalars are not json-serializable so any attributes of that value need to be converted. The attributes of variables can also have values that are not json-serializable, so those need to be fixed, as well.