### PR TITLE
Added Kerchunk support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -49,3 +49,22 @@ This generates the [TerraClimate STAC item](examples/terraclimate/item.json).
 
 See [examples/daymet/generate.py](examples/daymet/generate.py) for an example using the Python API.
 
+
+## Kerchunk support
+
+[Kerchunk](https://fsspec.github.io/kerchunk/) is a project and specification
+for representing chunked, compressed data where only the metadata and
+*references* to chunks of remote data are stored. You might want to include the
+Kerchunk metadata in a STAC item.
+
+To do this, generate the Kerchunk indices and provide them as the
+`kerchunk_indices` argument to `xarray_to_stac`.
+
+```python
+>>> from stactools.noaa_nwm import stac
+>>> import kerchunk.hdf
+
+>>> href = "https://noaanwm.blob.core.windows.net/nwm/nwm.20231010/short_range/nwm.t00z.short_range.channel_rt.f001.conus.nc"
+>>> indices = kerchunk.hdf.SingleHdf5ToZarr(href).translate()
+>>> item = stac.create_item(href, kerchunk_indices=indices)
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,34 +3,32 @@ requires = ["flit_core >=2,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
-name = "xstac"
-author = "Tom Augspurger"
-author-email = "taugspurger@microsoft.com"
-classifiers = [ "License :: OSI Approved :: MIT License",]
-dependencies = [
-    "cf_xarray",
-    "xarray",
-    "numpy",
-    "pystac>=1.0.0b3",
-    "pandas",
-    "pyproj",
-    "pydantic",
-    "zarr",
-    "jsonschema",
-    "dask[array]",  # for chunking
-    # these are just for generate
-    "fsspec[http]",
+authors = [
+  { email = "tom.w.augspurger@gmail.com" },
+  { name = "Tom Augspurger" },
 ]
-requires-python = ">=3.6"
+name = "xstac"
+# author-email = "taugspurger@microsoft.com"
+classifiers = ["License :: OSI Approved :: MIT License"]
+dependencies = [
+  "cf_xarray",
+  "xarray",
+  "numpy",
+  "pystac>=1.0.0b3",
+  "pandas",
+  "pyproj",
+  "pydantic",
+  "zarr",
+  "jsonschema",
+  "dask[array]",     # for chunking
+  # these are just for generate
+  "fsspec[http]",
+]
+requires-python = ">=3.10"
 dynamic = ["version", "description"]
 
 [project.optional-dependencies]
-dev = [
-  "pytest",
-  "pre-commit",
-  "shapely",
-  "cftime",
-]
+dev = ["pytest", "pre-commit", "shapely", "cftime", "kerchunk", "h5netcdf", "fsspec"]
 
 [project.scripts]
 xstac = "xstac._generate:main"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,7 +194,7 @@ def collection_expected_dims(coords):
             "extent": [-5802250.0, -5519250.0],
             "step": 1000.0,
             "reference_system": {
-                "$schema": "https://proj.org/schemas/v0.6/projjson.schema.json",
+                "$schema": "https://proj.org/schemas/v0.7/projjson.schema.json",
                 "type": "ProjectedCRS",
                 "name": "undefined",
                 "base_crs": {
@@ -297,7 +297,7 @@ def collection_expected_dims(coords):
             "extent": [-622000.0, -39000.0],
             "step": -1000.0,
             "reference_system": {
-                "$schema": "https://proj.org/schemas/v0.6/projjson.schema.json",
+                "$schema": "https://proj.org/schemas/v0.7/projjson.schema.json",
                 "type": "ProjectedCRS",
                 "name": "undefined",
                 "base_crs": {
@@ -492,7 +492,7 @@ def item_expected_dims(coords):
             "extent": [-5802250.0, -5519250.0],
             "step": 1000.0,
             "reference_system": {
-                "$schema": "https://proj.org/schemas/v0.6/projjson.schema.json",
+                "$schema": "https://proj.org/schemas/v0.7/projjson.schema.json",
                 "type": "ProjectedCRS",
                 "name": "undefined",
                 "base_crs": {
@@ -595,7 +595,7 @@ def item_expected_dims(coords):
             "extent": [-622000.0, -39000.0],
             "step": -1000.0,
             "reference_system": {
-                "$schema": "https://proj.org/schemas/v0.6/projjson.schema.json",
+                "$schema": "https://proj.org/schemas/v0.7/projjson.schema.json",
                 "type": "ProjectedCRS",
                 "name": "undefined",
                 "base_crs": {

--- a/tests/test_kerchunk.py
+++ b/tests/test_kerchunk.py
@@ -1,5 +1,4 @@
 import pystac
-import pytest
 
 import xarray as xr
 import kerchunk.hdf

--- a/tests/test_kerchunk.py
+++ b/tests/test_kerchunk.py
@@ -1,0 +1,78 @@
+import pystac
+import pytest
+
+import xarray as xr
+import kerchunk.hdf
+import fsspec
+
+import xstac
+
+
+def test_add_kerchunk(ds: xr.Dataset, item_template, tmp_path):
+    p = tmp_path / "test.nc"
+    ds.to_netcdf(p, engine="h5netcdf")
+
+    indices = kerchunk.hdf.SingleHdf5ToZarr(str(p)).translate()
+    result: pystac.Item = xstac.xarray_to_stac(
+        ds, template=item_template, kerchunk_indices=indices
+    )
+
+    assert result.properties["kerchunk:zattrs"] == {
+        "Conventions": "CF-1.6",
+        "Version_data": "Daymet Data Version 4.0",
+        "Version_software": "Daymet Software Version 4.0",
+        "citation": "Please see http://daymet.ornl.gov/ for "
+        "current Daymet data citation information",
+        "references": "Please see http://daymet.ornl.gov/ for "
+        "current information on Daymet references",
+        "source": "Daymet Software Version 4.0",
+        "start_year": 1980,
+    }
+    assert result.properties["kerchunk:zgroup"] == {"zarr_format": 2}
+
+    assert result.properties["cube:dimensions"]["time"]["kerchunk:zarray"] == {
+        "chunks": [40],
+        "compressor": None,
+        "dtype": "<i8",
+        "fill_value": None,
+        "filters": None,
+        "order": "C",
+        "shape": [40],
+        "zarr_format": 2,
+    }
+    assert result.properties["cube:variables"]["prcp"]["kerchunk:zarray"] == {
+        "chunks": [40, 584, 284],
+        "compressor": None,
+        "dtype": "<f4",
+        "fill_value": "NaN",
+        "filters": None,
+        "order": "C",
+        "shape": [40, 584, 284],
+        "zarr_format": 2,
+    }
+
+    for attr in ["cube:dimensions", "cube:variables"]:
+        for v in result.properties[attr].values():
+            assert {"kerchunk:value", "kerchunk:zarray", "kerchunk:zattrs"} <= set(
+                v.keys()
+            )
+
+
+def test_stac_to_kerchunk(ds: xr.Dataset, item_template, tmp_path):
+    p = tmp_path / "test.nc"
+    ds.to_netcdf(p, engine="h5netcdf")
+
+    indices = kerchunk.hdf.SingleHdf5ToZarr(str(p)).translate()
+    item: pystac.Item = xstac.xarray_to_stac(
+        ds, template=item_template, kerchunk_indices=indices
+    )
+
+    indices = xstac.kerchunk.stac_to_kerchunk(item)
+
+    result = xr.open_dataset(
+        fsspec.filesystem("reference", fo=indices).get_mapper(),
+        engine="zarr",
+        consolidated=False,
+    )
+
+    xr.testing.assert_equal(ds, result)

--- a/xstac/__init__.py
+++ b/xstac/__init__.py
@@ -2,7 +2,8 @@
 xstac
 """
 from ._xstac import xarray_to_stac, fix_attrs
+from . import _kerchunk as kerchunk
 
 __version__ = "1.1.0"
 
-__all__ = ["xarray_to_stac", "fix_attrs"]
+__all__ = ["xarray_to_stac", "fix_attrs", "kerchunk"]

--- a/xstac/_kerchunk.py
+++ b/xstac/_kerchunk.py
@@ -1,0 +1,84 @@
+from typing import Any
+
+import collections
+import json
+import pystac
+
+
+def add_kerchunk_indices(d: dict[str, Any], item: pystac.Item) -> pystac.Item:
+    """
+    Add Kerchunk metadata to a STAC item.
+
+    Notes
+    -----
+    We follow some high-level guidelines:
+
+    1. STAC metadata should always be concrete objects (no JSON strings
+       in the properties)
+    2. We don't duplicate anything already in the STAC metadata
+       (modulo some TODOs around zattrs).
+
+    The output STAC item will have some additional properties:
+
+    - Global `.zgroup` and `.zattrs` are added add `kerchunk:zgroup` and
+      and `kerchunk:zattrs`.
+    - For each dimension and variable, `.zarray` and `.zattrs` are added as
+        `kerchunk:zarray` and `kerchunk:zattrs`.
+    - For each chunk of a variable, the index is added under `kerchunk:value`,
+      as a mapping `kerchunk:value[i.j.k]`.
+    """
+    item = item.clone()
+    refs = d["refs"]
+    for k, v in refs.items():
+        match k.split("/"):
+            case [".zgroup"]:
+                item.properties["kerchunk:zgroup"] = json.loads(v)
+            case [".zattrs"]:
+                item.properties["kerchunk:zattrs"] = json.loads(v)
+            case [variable, ".zarray"]:
+                if v := item.properties["cube:dimensions"].get(variable):
+                    v["kerchunk:zarray"] = json.loads(refs[k])
+                elif v := item.properties["cube:variables"].get(variable):
+                    v["kerchunk:zarray"] = json.loads(refs[k])
+            case [variable, ".zattrs"]:
+                # TODO(Tom): we ideally can get zattrs from the variable.
+                # I think we don't need this?
+                if v := item.properties["cube:dimensions"].get(variable):
+                    v["kerchunk:zattrs"] = json.loads(refs[k])
+                elif v := item.properties["cube:variables"].get(variable):
+                    v["kerchunk:zattrs"] = json.loads(refs[k])
+            case [variable, index]:
+                if v := item.properties["cube:dimensions"].get(variable):
+                    v.setdefault("kerchunk:value", collections.defaultdict(dict))
+                    v["kerchunk:value"][index] = refs[k]
+                elif v := item.properties["cube:variables"].get(variable):
+                    v.setdefault("kerchunk:value", collections.defaultdict(dict))
+                    v["kerchunk:value"][index] = refs[k]
+
+    for attr in ["cube:dimensions", "cube:variables"]:
+        for k in item.properties[attr]:
+            v = item.properties[attr][k].get("kerchunk:value")
+            if v:
+                item.properties[attr][k]["kerchunk:value"] = dict(v)
+    return item
+
+
+def stac_to_kerchunk(item: pystac.Item, kerchunk_version: int = 1) -> dict[str, Any]:
+    """
+    Derive Kerchunk indices from a STAC item.
+    """
+    refs = {}
+    refs[".zgroup"] = json.dumps(item.properties["kerchunk:zgroup"])
+    refs[".zattrs"] = json.dumps(item.properties["kerchunk:zattrs"])
+
+    for attr in ["cube:dimensions", "cube:variables"]:
+        cd = item.properties[attr]
+        for k in cd:
+            refs[f"{k}/.zarray"] = json.dumps(cd[k]["kerchunk:zarray"])
+            # TODO: derive from datacube stuff, ARRAY_DIMENSIONS
+            refs[f"{k}/.zattrs"] = json.dumps(cd[k]["kerchunk:zattrs"])
+            for i in cd[k]["kerchunk:value"]:
+                refs[f"{k}/{i}"] = cd[k]["kerchunk:value"][i]
+
+    d = {"version": kerchunk_version, "refs": refs}
+    return d

--- a/xstac/_xstac.py
+++ b/xstac/_xstac.py
@@ -62,10 +62,7 @@ def _bbox_to_geometry(bbox):
 
 def fix_attrs(ds):
     def fix_value(value):
-        if isinstance(value, (np.ndarray, np.number)):
-            return value.tolist()
-
-        return value
+        return xr.backends.zarr.encode_zarr_attr_value(value)
 
     def fix_dict(attrs):
         return {name: fix_value(value) for name, value in attrs.items()}

--- a/xstac/_xstac.py
+++ b/xstac/_xstac.py
@@ -473,7 +473,6 @@ def xarray_to_stac(
                     del ext.properties[obj][var][k]
     stac_obj = result
 
-
     if kerchunk_indices:
         stac_obj = add_kerchunk_indices(kerchunk_indices, stac_obj)
 


### PR DESCRIPTION
This updates `create_item` to optionally accept a kechunk indices object. When provided, we'll add the Kerchunk indicies to the STAC item.

We also provide a helper to translate from STAC to Kerchunk.