### PR TITLE
Fixup attrs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 htmlcov
 dist
 .direnv
+.venv

--- a/tests/test_xstac.py
+++ b/tests/test_xstac.py
@@ -1,3 +1,4 @@
+import json
 import pyproj
 import pytest
 import pystac
@@ -169,8 +170,4 @@ def test_fixup_numpy_attrs_by_default(ds, item_template):
     ds.prcp.attrs["values"] = np.zeros(2)
     result = xarray_to_stac(ds, item_template, temporal_dimension=False)
     assert result.properties["cube:variables"]["prcp"]["attrs"]["values"] == [0.0, 0.0]
-    try:
-        import json
-        json.dumps(result.to_dict())
-    except Exception:
-        pytest.fail("Failed to serialize to JSON")
+    json.dumps(result.to_dict())

--- a/tests/test_xstac.py
+++ b/tests/test_xstac.py
@@ -166,6 +166,7 @@ def test_disable_infer_temporal_extent(ds, item_template):
     result = xarray_to_stac(ds, item_template, temporal_dimension=False)
     assert "start_datetime" not in result.properties
 
+
 def test_fixup_numpy_attrs_by_default(ds, item_template):
     ds.prcp.attrs["values"] = np.zeros(2)
     result = xarray_to_stac(ds, item_template, temporal_dimension=False)

--- a/tests/test_xstac.py
+++ b/tests/test_xstac.py
@@ -164,3 +164,13 @@ def test_disable_infer_temporal_extent(ds, item_template):
     # del item_template["properties"]["datetime"]
     result = xarray_to_stac(ds, item_template, temporal_dimension=False)
     assert "start_datetime" not in result.properties
+
+def test_fixup_numpy_attrs_by_default(ds, item_template):
+    ds.prcp.attrs["values"] = np.zeros(2)
+    result = xarray_to_stac(ds, item_template, temporal_dimension=False)
+    assert result.properties["cube:variables"]["prcp"]["attrs"]["values"] == [0.0, 0.0]
+    try:
+        import json
+        json.dumps(result.to_dict())
+    except Exception:
+        pytest.fail("Failed to serialize to JSON")

--- a/xstac/_xstac.py
+++ b/xstac/_xstac.py
@@ -339,6 +339,8 @@ def xarray_to_stac(
     **additional_dimensions:
         A dictionary with keys ``extent``, ``values``, ``step``.
     """
+    ds = fix_attrs(ds)
+
     temporal_dimension = maybe_use_cf_standard_axis(
         temporal_dimension, "temporal_dimension", ds
     )


### PR DESCRIPTION
Addresses #30 , `xarray` tends to put `numpy` arrays in `attrs` which are not immediately JSON serializable. 