### PR TITLE
Add dimension names from coords for CRS lookup

### DIFF
--- a/tests/test_xstac.py
+++ b/tests/test_xstac.py
@@ -51,22 +51,11 @@ def test_xarray_to_stac(
     assert dimensions == collection_expected_dims
     assert result.extra_fields["cube:variables"] == collection_expected_vars
 
-@pytest.mark.parametrize("dimension_key", ["x_dimension", "y_dimension", "temporal_dimension", "longitude", "latitude"])
-def test_maybe_use_cf_standard_axis(ds, dimension_key):
-    match dimension_key:
-        case "x_dimension":
-            expected = "x"
-        case "y_dimension":
-            expected = "y"
-        case "temporal_dimension":
-            expected = "time"
-        case "longitude":
-            expected = "lon"
-        case "latitude":
-            expected = "lat"
-        case _:
-            expected = dimension_key
-    assert maybe_use_cf_standard_axis(None, dimension_key, ds) == expected
+@pytest.mark.parametrize(
+    ("dimension_key", "expected_value"), 
+    [("x_dimension", "x"), ("y_dimension", "y"), ("temporal_dimension", "time"), ("longitude", "lon"), ("latitude", "lat")])
+def test_maybe_use_cf_standard_axis(ds, dimension_key, expected_value):
+    assert maybe_use_cf_standard_axis(None, dimension_key, ds) == expected_value
 
 def test_validation_with_none(ds_without_spatial_dims):
     # https://github.com/TomAugspurger/xstac/issues/9

--- a/tests/test_xstac.py
+++ b/tests/test_xstac.py
@@ -6,7 +6,11 @@ import numpy as np
 import xarray as xr
 
 from xstac import xarray_to_stac, fix_attrs
-from xstac._xstac import _bbox_to_geometry, maybe_infer_reference_system, maybe_use_cf_standard_axis
+from xstac._xstac import (
+    _bbox_to_geometry,
+    maybe_infer_reference_system,
+    maybe_use_cf_standard_axis,
+)
 
 
 # def test_no_time_dimension(ds, collection_template):
@@ -51,11 +55,20 @@ def test_xarray_to_stac(
     assert dimensions == collection_expected_dims
     assert result.extra_fields["cube:variables"] == collection_expected_vars
 
+
 @pytest.mark.parametrize(
-    ("dimension_key", "expected_value"), 
-    [("x_dimension", "x"), ("y_dimension", "y"), ("temporal_dimension", "time"), ("longitude", "lon"), ("latitude", "lat")])
+    ("dimension_key", "expected_value"),
+    [
+        ("x_dimension", "x"),
+        ("y_dimension", "y"),
+        ("temporal_dimension", "time"),
+        ("longitude", "lon"),
+        ("latitude", "lat"),
+    ],
+)
 def test_maybe_use_cf_standard_axis(ds, dimension_key, expected_value):
     assert maybe_use_cf_standard_axis(None, dimension_key, ds) == expected_value
+
 
 def test_validation_with_none(ds_without_spatial_dims):
     # https://github.com/TomAugspurger/xstac/issues/9

--- a/tests/test_xstac.py
+++ b/tests/test_xstac.py
@@ -6,7 +6,7 @@ import numpy as np
 import xarray as xr
 
 from xstac import xarray_to_stac, fix_attrs
-from xstac._xstac import _bbox_to_geometry, maybe_infer_reference_system
+from xstac._xstac import _bbox_to_geometry, maybe_infer_reference_system, maybe_use_cf_standard_axis
 
 
 # def test_no_time_dimension(ds, collection_template):
@@ -51,6 +51,22 @@ def test_xarray_to_stac(
     assert dimensions == collection_expected_dims
     assert result.extra_fields["cube:variables"] == collection_expected_vars
 
+@pytest.mark.parametrize("dimension_key", ["x_dimension", "y_dimension", "temporal_dimension", "longitude", "latitude"])
+def test_maybe_use_cf_standard_axis(ds, dimension_key):
+    match dimension_key:
+        case "x_dimension":
+            expected = "x"
+        case "y_dimension":
+            expected = "y"
+        case "temporal_dimension":
+            expected = "time"
+        case "longitude":
+            expected = "lon"
+        case "latitude":
+            expected = "lat"
+        case _:
+            expected = dimension_key
+    assert maybe_use_cf_standard_axis(None, dimension_key, ds) == expected
 
 def test_validation_with_none(ds_without_spatial_dims):
     # https://github.com/TomAugspurger/xstac/issues/9

--- a/xstac/_xstac.py
+++ b/xstac/_xstac.py
@@ -26,7 +26,7 @@ from ._kerchunk import add_kerchunk_indices
 
 SCHEMA_URI = "https://stac-extensions.github.io/datacube/v2.0.0/schema.json"
 
-CF_STANDARD_AXES = dict(temporal_dimension="T", x_dimension="X", y_dimension="Y")
+CF_STANDARD_AXES = dict(temporal_dimension="T", x_dimension="X", y_dimension="Y", latitude="latitude", longitude="longitude")
 
 
 def maybe_use_cf_standard_axis(kw, kw_name, ds):

--- a/xstac/_xstac.py
+++ b/xstac/_xstac.py
@@ -26,7 +26,13 @@ from ._kerchunk import add_kerchunk_indices
 
 SCHEMA_URI = "https://stac-extensions.github.io/datacube/v2.0.0/schema.json"
 
-CF_STANDARD_AXES = dict(temporal_dimension="T", x_dimension="X", y_dimension="Y", latitude="latitude", longitude="longitude")
+CF_STANDARD_AXES = dict(
+    temporal_dimension="T",
+    x_dimension="X",
+    y_dimension="Y",
+    latitude="latitude",
+    longitude="longitude",
+)
 
 
 def maybe_use_cf_standard_axis(kw, kw_name, ds):


### PR DESCRIPTION
Based on the doc: https://cf-xarray.readthedocs.io/en/latest/coord_axes.html, cf_xarray can refer to named dimensions by standard axis or coordinate names. The difference is that axis names are "X"/"Y"/"T" while coordinate names are "longitude"/"latitude"/"time". In some datasets, "X" and "Y" don't necessarily correspond to "longitude" and "latitude", so we need to add "longitude" and "latitude" explicitly to the dimension names for CRS lookup.